### PR TITLE
Do not try to prevent labels overlap when `disableRange == YES`

### DIFF
--- a/Pod/Classes/TTRangeSlider.m
+++ b/Pod/Classes/TTRangeSlider.m
@@ -203,7 +203,7 @@ static const CGFloat kLabelsFontSize = 12.0f;
     float newRightMostXInMinLabel = newMinLabelCenter.x + minLabelTextSize.width/2;
     float newSpacingBetweenTextLabels = newLeftMostXInMaxLabel - newRightMostXInMinLabel;
 
-    if (newSpacingBetweenTextLabels > minSpacingBetweenLabels) {
+    if (self.disableRange == YES || newSpacingBetweenTextLabels > minSpacingBetweenLabels) {
         self.minLabel.position = newMinLabelCenter;
         self.maxLabel.position = newMaxLabelCenter;
     }


### PR DESCRIPTION
Without this fix, the `maxLabel` would not go all the way to the left
due to the `minLabel` being accounted for even if hidden.