### PR TITLE
Add `didEndTouchesInRangeSlider:` delegate method

### DIFF
--- a/Pod/Classes/TTRangeSlider.m
+++ b/Pod/Classes/TTRangeSlider.m
@@ -342,6 +342,9 @@ static const CGFloat kLabelsFontSize = 12.0f;
         self.rightHandleSelected = NO;
         [self animateHandle:self.rightHandle withSelection:NO];
     }
+    if ([self.delegate respondsToSelector:@selector(didEndTouchesInRangeSlider:)]) {
+        [self.delegate didEndTouchesInRangeSlider:self];
+    }
 }
 
 #pragma mark - Animation

--- a/Pod/Classes/TTRangeSliderDelegate.h
+++ b/Pod/Classes/TTRangeSliderDelegate.h
@@ -13,4 +13,8 @@
 
 -(void)rangeSlider:(TTRangeSlider *)sender didChangeSelectedMinimumValue:(float)selectedMinimum andMaximumValue:(float)selectedMaximum;
 
+@optional
+
+- (void)didEndTouchesInRangeSlider:(TTRangeSlider *)sender;
+
 @end


### PR DESCRIPTION
This patch adds a delegate method that makes it easy to handle the final value after a series of changes made by the user. (Yes, you can already do it by hooking into `UIControlEventTouchUpInside`, but since we have a delegate, why not make it easy?)