### PR TITLE
Replace -setTintColor: with -tintColorDidChange

### DIFF
--- a/Pod/Classes/TTRangeSlider.m
+++ b/Pod/Classes/TTRangeSlider.m
@@ -138,6 +138,25 @@ static const CGFloat kLabelsFontSize = 12.0f;
 }
 
 
+- (void)tintColorDidChange {
+    CGColorRef color = self.tintColor.CGColor;
+
+    [CATransaction begin];
+    [CATransaction setAnimationDuration:0.5];
+    [CATransaction setAnimationTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut] ];
+    self.sliderLine.backgroundColor = color;
+    self.leftHandle.backgroundColor = color;
+    self.rightHandle.backgroundColor = color;
+
+    if (self.minLabelColour == nil){
+        self.minLabel.foregroundColor = color;
+    }
+    if (self.maxLabelColour == nil){
+        self.maxLabel.foregroundColor = color;
+    }
+    [CATransaction commit];
+}
+
 - (float)getPercentageAlongLineForValue:(float) value {
     if (self.minValue == self.maxValue){
         return 0; //stops divide by zero errors where maxMinDif would be zero. If the min and max are the same the percentage has no point.
@@ -398,27 +417,6 @@ static const CGFloat kLabelsFontSize = 12.0f;
 
 
 #pragma mark - Properties
--(void)setTintColor:(UIColor *)tintColor{
-    [super setTintColor:tintColor];
-
-    struct CGColor *color = self.tintColor.CGColor;
-
-    [CATransaction begin];
-    [CATransaction setAnimationDuration:0.5];
-    [CATransaction setAnimationTimingFunction:[CAMediaTimingFunction functionWithName:kCAMediaTimingFunctionEaseInEaseOut] ];
-    self.sliderLine.backgroundColor = color;
-    self.leftHandle.backgroundColor = color;
-    self.rightHandle.backgroundColor = color;
-
-    if (self.minLabelColour == nil){
-        self.minLabel.foregroundColor = color;
-    }
-    if (self.maxLabelColour == nil){
-        self.maxLabel.foregroundColor = color;
-    }
-    [CATransaction commit];
-}
-
 - (void)setDisableRange:(BOOL)disableRange {
     _disableRange = disableRange;
     if (_disableRange){


### PR DESCRIPTION
This fixes a problem where TTRangeSlider would not inherit the `tintColor` of the parent view when using Interface Builder.

Suppose you're dropping a TTRangeSlider in your storyboard, and change the `tintColor` of the parent view to `redColor`. TTRangeSlider would not change to red, and stay the default blue color, because `setTintColor:` would never be called.

The "right" way to handle tint color changes is to override [`tintColorDidChange`](https://developer.apple.com/library/ios/documentation/UIKit/Reference/UIView_Class/#//apple_ref/occ/instm/UIView/tintColorDidChange):

> The system calls this method on a view when your code changes the value of the tintColor property on that view. In addition, the system calls this method on a subview that inherits a changed interaction tint color.

> In your implementation, refresh the view rendering as needed.


I also took the opportunity to replace `struct CGColor *` with `CGColorRef`. The rest of the method is kept intact.