### PR TITLE
Allow greater than max value

### DIFF
--- a/Pod/Classes/TTRangeSlider.h
+++ b/Pod/Classes/TTRangeSlider.h
@@ -35,6 +35,11 @@ IB_DESIGNABLE
 @property (nonatomic, assign) IBInspectable float selectedMaximum;
 
 /**
+ * Appends + to the end of maxLabel and returns infinity. Does not return maxValue and inf, just inf. The default value is NO
+ */
+@property (nonatomic, assign) IBInspectable BOOL allowInfiniteSelectedMax;
+
+/**
  * Each handle in the slider has a label above it showing the current selected value. By default, this is displayed as a decimal format.
  * You can override this default here by supplying your own NSNumberFormatter. For example, you could supply an NSNumberFormatter that has a currency style, or a prefix or suffix.
  * If this property is nil, the default decimal format will be used. Note: If you want no labels at all, please use the hideLabels flag. */

--- a/Pod/Classes/TTRangeSlider.m
+++ b/Pod/Classes/TTRangeSlider.m
@@ -366,8 +366,13 @@ static const CGFloat kLabelsFontSize = 12.0f;
 
     //update the delegate
     if (self.delegate && (self.leftHandleSelected || self.rightHandleSelected)){
-        float max = (self.allowInfiniteSelectedMax) ? INFINITY : self.selectedMaximum;
-        [self.delegate rangeSlider:self didChangeSelectedMinimumValue:self.selectedMinimum andMaximumValue:max];
+      if (self.allowInfiniteSelectedMax &&
+          [NSNumber numberWithFloat:self.selectedMaximum] == [NSNumber numberWithFloat:self.maxValue]) {
+        [self.delegate rangeSlider:self didChangeSelectedMinimumValue:self.selectedMinimum andMaximumValue:INFINITY];
+      } else {
+        [self.delegate rangeSlider:self didChangeSelectedMinimumValue:self.selectedMinimum andMaximumValue:self.selectedMaximum];
+      }
+      
     }
 }
 

--- a/Pod/Classes/TTRangeSlider.m
+++ b/Pod/Classes/TTRangeSlider.m
@@ -214,6 +214,11 @@ static const CGFloat kLabelsFontSize = 12.0f;
     return CGRectGetMinX(self.sliderLine.frame) + offset;
 }
 
+- (BOOL)selectedMaximumShouldBeInfinity
+{
+  return self.allowInfiniteSelectedMax && [NSNumber numberWithFloat:self.selectedMaximum] == [NSNumber numberWithFloat:self.maxValue];
+}
+
 - (void)updateLabelValues {
     if (self.hideLabels || [self.numberFormatterOverride isEqual:[NSNull null]]){
         self.minLabel.string = @"";
@@ -225,7 +230,7 @@ static const CGFloat kLabelsFontSize = 12.0f;
 
     self.minLabel.string = [formatter stringFromNumber:@(self.selectedMinimum)];
   
-    if (self.allowInfiniteSelectedMax && [NSNumber numberWithFloat:self.selectedMaximum] == [NSNumber numberWithFloat:self.maxValue] ) {
+    if ([self selectedMaximumShouldBeInfinity]) {
       self.maxLabel.string = [NSString stringWithFormat:@"%@+", [formatter stringFromNumber:@(self.selectedMaximum)]];
     } else {
       self.maxLabel.string = [formatter stringFromNumber:@(self.selectedMaximum)];
@@ -366,8 +371,7 @@ static const CGFloat kLabelsFontSize = 12.0f;
 
     //update the delegate
     if (self.delegate && (self.leftHandleSelected || self.rightHandleSelected)){
-      if (self.allowInfiniteSelectedMax &&
-          [NSNumber numberWithFloat:self.selectedMaximum] == [NSNumber numberWithFloat:self.maxValue]) {
+      if ([self selectedMaximumShouldBeInfinity]) {
         [self.delegate rangeSlider:self didChangeSelectedMinimumValue:self.selectedMinimum andMaximumValue:INFINITY];
       } else {
         [self.delegate rangeSlider:self didChangeSelectedMinimumValue:self.selectedMinimum andMaximumValue:self.selectedMaximum];

--- a/Pod/Classes/TTRangeSlider.m
+++ b/Pod/Classes/TTRangeSlider.m
@@ -39,6 +39,7 @@ static const CGFloat kLabelsFontSize = 12.0f;
     _selectedMinimum = 10;
     _maxValue = 100;
     _selectedMaximum  = 90;
+    _allowInfiniteSelectedMax = NO;
 
     _minDistance = -1;
     _maxDistance = -1;
@@ -223,8 +224,13 @@ static const CGFloat kLabelsFontSize = 12.0f;
     NSNumberFormatter *formatter = (self.numberFormatterOverride != nil) ? self.numberFormatterOverride : self.decimalNumberFormatter;
 
     self.minLabel.string = [formatter stringFromNumber:@(self.selectedMinimum)];
-    self.maxLabel.string = [formatter stringFromNumber:@(self.selectedMaximum)];
-    
+  
+    if (self.allowInfiniteSelectedMax && [NSNumber numberWithFloat:self.selectedMaximum] == [NSNumber numberWithFloat:self.maxValue] ) {
+      self.maxLabel.string = [NSString stringWithFormat:@"%@+", [formatter stringFromNumber:@(self.selectedMaximum)]];
+    } else {
+      self.maxLabel.string = [formatter stringFromNumber:@(self.selectedMaximum)];
+    }
+
     self.minLabelTextSize = [self.minLabel.string sizeWithAttributes:@{NSFontAttributeName:self.minLabelFont}];
     self.maxLabelTextSize = [self.maxLabel.string sizeWithAttributes:@{NSFontAttributeName:self.maxLabelFont}];
 }
@@ -360,7 +366,8 @@ static const CGFloat kLabelsFontSize = 12.0f;
 
     //update the delegate
     if (self.delegate && (self.leftHandleSelected || self.rightHandleSelected)){
-        [self.delegate rangeSlider:self didChangeSelectedMinimumValue:self.selectedMinimum andMaximumValue:self.selectedMaximum];
+        float max = (self.allowInfiniteSelectedMax) ? INFINITY : self.selectedMaximum;
+        [self.delegate rangeSlider:self didChangeSelectedMinimumValue:self.selectedMinimum andMaximumValue:max];
     }
 }
 


### PR DESCRIPTION
This returns `$150+` if enabled. Use case is when we need to indicate to the user that we can include a greater than max value in the range selected.
