### PR TITLE
Send UIControlEventValueChanged

### DIFF
--- a/Example/RangeSliderDemo/ViewController.m
+++ b/Example/RangeSliderDemo/ViewController.m
@@ -16,6 +16,10 @@
 
 @implementation ViewController
 
+- (void)logControlEvent:(TTRangeSlider *)sender {
+    NSLog(@"Standard slider updated. Min Value: %.0f Max Value: %.0f", sender.selectedMinimum, sender.selectedMaximum);
+}
+
 - (void)viewDidLoad {
     [super viewDidLoad];
     // Do any additional setup after loading the view, typically from a nib.
@@ -26,6 +30,7 @@
     self.rangeSlider.maxValue = 200;
     self.rangeSlider.selectedMinimum = 50;
     self.rangeSlider.selectedMaximum = 150;
+    [self.rangeSlider addTarget:self action:@selector(logControlEvent:) forControlEvents:UIControlEventValueChanged];
     
     //currency range slider
     self.rangeSliderCurrency.delegate = self;
@@ -62,10 +67,7 @@
 
 #pragma mark TTRangeSliderViewDelegate
 -(void)rangeSlider:(TTRangeSlider *)sender didChangeSelectedMinimumValue:(float)selectedMinimum andMaximumValue:(float)selectedMaximum{
-    if (sender == self.rangeSlider){
-        NSLog(@"Standard slider updated. Min Value: %.0f Max Value: %.0f", selectedMinimum, selectedMaximum);
-    }
-    else if (sender == self.rangeSliderCurrency) {
+    if (sender == self.rangeSliderCurrency) {
         NSLog(@"Currency slider updated. Min Value: %.0f Max Value: %.0f", selectedMinimum, selectedMaximum);
     }
     else if (sender == self.rangeSliderCustom){

--- a/Example/RangeSliderDemo/ViewController.m
+++ b/Example/RangeSliderDemo/ViewController.m
@@ -25,7 +25,6 @@
     // Do any additional setup after loading the view, typically from a nib.
     
     //standard rsnge slider
-    self.rangeSlider.delegate = self;
     self.rangeSlider.minValue = 0;
     self.rangeSlider.maxValue = 200;
     self.rangeSlider.selectedMinimum = 50;

--- a/Pod/Classes/TTRangeSlider.h
+++ b/Pod/Classes/TTRangeSlider.h
@@ -10,6 +10,9 @@
 IB_DESIGNABLE
 @interface TTRangeSlider : UIControl <UIGestureRecognizerDelegate>
 
+/**
+ * Optional delegate.
+ */
 @property (nonatomic, weak) IBOutlet id<TTRangeSliderDelegate> delegate;
 
 /**

--- a/Pod/Classes/TTRangeSlider.m
+++ b/Pod/Classes/TTRangeSlider.m
@@ -398,9 +398,13 @@ static const CGFloat kLabelsFontSize = 12.0f;
     [self updateAccessibilityElements];
 
     //update the delegate
-    if (self.delegate && (self.leftHandleSelected || self.rightHandleSelected)){
+    if ([self.delegate respondsToSelector:@selector(rangeSlider:didChangeSelectedMinimumValue:andMaximumValue:)] &&
+        (self.leftHandleSelected || self.rightHandleSelected)){
+
         [self.delegate rangeSlider:self didChangeSelectedMinimumValue:self.selectedMinimum andMaximumValue:self.selectedMaximum];
     }
+
+    [self sendActionsForControlEvents:UIControlEventValueChanged];
 }
 
 - (BOOL)continueTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {

--- a/Pod/Classes/TTRangeSliderDelegate.h
+++ b/Pod/Classes/TTRangeSliderDelegate.h
@@ -11,12 +11,12 @@
 
 @protocol TTRangeSliderDelegate <NSObject>
 
+@optional
+
 /**
  * Called when the RangeSlider values are changed
  */
 -(void)rangeSlider:(TTRangeSlider *)sender didChangeSelectedMinimumValue:(float)selectedMinimum andMaximumValue:(float)selectedMaximum;
-
-@optional
 
 /**
  * Called when the user has finished interacting with the RangeSlider

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ The default slider ranges from 0->100 and has 10 preselected as the minimum, and
 
 Values that the user has selected are exposed using the `selectedMinimum` and `selectedMaximum` properties. You can also use these properties to change the selected values programatically if you wish.
 
+## Getting updates
+
+To be notified when the slider’s value changes, register your action method with the `UIControlEventValueChanged` event. At runtime, the slider calls your method in response to the user changing the slider’s value.
+
+Alternatively you can implement the `TTRangeSliderDelegate` protocol and respond to changes in the `rangeSlider:didChangeSelectedMinimumValue:andMaximumValue:` method.
+
 Other customisation of the control is done using the following properties:
 #### `tintColor`
 The tintColor property (which you can also set in Interface Builder) sets the overall colour of the control, including the colour of the line, the two handles, and the labels.


### PR DESCRIPTION
Sends a `UIControlEventValueChanged` event and makes the `Delegate` entirely optional. This is more in-line with standard `UIControl` design and `UISlider`. 