### PR TITLE
Set corner radius for slider when disable Range

### DIFF
--- a/Pod/Classes/TTRangeSlider.m
+++ b/Pod/Classes/TTRangeSlider.m
@@ -164,7 +164,8 @@ static const CGFloat kLabelsFontSize = 12.0f;
     self.sliderLine.frame = CGRectMake(lineLeftSide.x, lineLeftSide.y, lineRightSide.x-lineLeftSide.x, self.lineHeight);
     
     self.sliderLine.cornerRadius = self.lineHeight / 2.0;
-
+    self.sliderLineBetweenHandles.cornerRadius = self.lineHeight / 2.0;
+    
     [self updateLabelValues];
     [self updateHandlePositions];
     [self updateLabelPositions];


### PR DESCRIPTION
When `disableRange = true`, SliderLine was not round on the left

- Actual:
<img width="352" alt="screen shot 2017-07-28 at 9 19 55 pm" src="https://user-images.githubusercontent.com/6436310/28721587-16a47812-73db-11e7-9fbb-94fa48bc1699.png">

- Expected:
<img width="356" alt="screen shot 2017-07-28 at 9 28 29 pm" src="https://user-images.githubusercontent.com/6436310/28721787-bb0452a6-73db-11e7-9d5d-752757861637.png">
