### PR TITLE
Added the ability to have different colors on left/right handles

### DIFF
--- a/Pod/Classes/TTRangeSlider.h
+++ b/Pod/Classes/TTRangeSlider.h
@@ -126,6 +126,14 @@ IB_DESIGNABLE
 @property (nonatomic, strong) UIColor *handleColor;
 
 /**
+ *Handle independent colors for each handle.
+ *If set to nil, they will default to self.handleColor
+ */
+@property (nonatomic, strong) IBInspectable UIColor *leftHandleColor;
+@property (nonatomic, strong) IBInspectable UIColor *rightHandleColor;
+
+
+/**
  *Handle slider with custom border color, you can set custom border color for your handle
  */
 @property (nonatomic, strong) UIColor *handleBorderColor;

--- a/Pod/Classes/TTRangeSlider.m
+++ b/Pod/Classes/TTRangeSlider.m
@@ -74,6 +74,11 @@ static const CGFloat kLabelsFontSize = 12.0f;
     _labelPadding = 8.0;
 
     _labelPosition = LabelPositionAbove;
+    
+    
+    _leftHandleColor = nil;
+    _rightHandleColor = nil;
+    
 
     //draw the slider line
     self.sliderLine = [CALayer layer];
@@ -90,7 +95,7 @@ static const CGFloat kLabelsFontSize = 12.0f;
     //draw the minimum slider handle
     self.leftHandle = [CALayer layer];
     self.leftHandle.cornerRadius = self.handleDiameter / 2;
-    self.leftHandle.backgroundColor = self.tintColor.CGColor;
+    self.leftHandle.backgroundColor = self.leftHandleColor.CGColor;
     self.leftHandle.borderWidth = self.handleBorderWidth;
     self.leftHandle.borderColor = self.handleBorderColor.CGColor;
     [self.layer addSublayer:self.leftHandle];
@@ -98,7 +103,7 @@ static const CGFloat kLabelsFontSize = 12.0f;
     //draw the maximum slider handle
     self.rightHandle = [CALayer layer];
     self.rightHandle.cornerRadius = self.handleDiameter / 2;
-    self.rightHandle.backgroundColor = self.tintColor.CGColor;
+    self.rightHandle.backgroundColor = self.rightHandleColor.CGColor;
     self.rightHandle.borderWidth = self.handleBorderWidth;
     self.rightHandle.borderColor = self.handleBorderColor.CGColor;
     [self.layer addSublayer:self.rightHandle];
@@ -621,6 +626,16 @@ static const CGFloat kLabelsFontSize = 12.0f;
     _handleColor = handleColor;
     self.leftHandle.backgroundColor = [handleColor CGColor];
     self.rightHandle.backgroundColor = [handleColor CGColor];
+}
+
+- (void)setLeftHandleColor:(UIColor *)leftHandleColor {
+    _leftHandleColor = leftHandleColor ?: self.handleColor;
+    self.leftHandle.backgroundColor = [leftHandleColor CGColor];
+}
+
+- (void)setRightHandleColor:(UIColor *)rightHandleColor {
+    _rightHandleColor = rightHandleColor ?: self.handleColor;
+    self.rightHandle.backgroundColor = [rightHandleColor CGColor];
 }
 
 -(void)setHandleBorderColor:(UIColor *)handleBorderColor{

--- a/TTRangeSlider.podspec
+++ b/TTRangeSlider.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "TTRangeSlider"
-  s.version          = "1.0.5"
+  s.version          = "1.0.6"
   s.summary          = "A slider that allows you to pick a range"
   s.description      = <<-DESC
                        A slider, similar in style to UISlider, but has two handles instead of one, allowing you to pick a minimum and maximum range.
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   # s.screenshots     = "www.example.com/screenshots_1", "www.example.com/screenshots_2"
   s.license          = 'MIT'
   s.author           = { "Tom Thorpe" => "code@tomthorpe.co.uk" }
-  s.source           = { :git => "https://github.com/TomThorpe/TTRangeSlider.git", :tag => 'v1.0.5'  }
+  s.source           = { :git => "https://github.com/TomThorpe/TTRangeSlider.git", :tag => 'v1.0.6'  }
   s.platform     = :ios, '7.0'
   s.requires_arc = true
 


### PR DESCRIPTION
Added `leftHandleColor` and `rightHandleColor` to draw handles with different colors.
When `leftHandleColor` or `rightHandleColor` is set to `nil`, it will default to `self.handleColor`.

It hasn't been done to colors like borders and stuff, but probably should.