### PR TITLE
Informing in touches delegate which handle was selected

### DIFF
--- a/Pod/Classes/TTRangeSlider.m
+++ b/Pod/Classes/TTRangeSlider.m
@@ -360,8 +360,8 @@ static const CGFloat kLabelsFontSize = 12.0f;
             }
         }
 
-        if ([self.delegate respondsToSelector:@selector(didStartTouchesInRangeSlider:)]){
-            [self.delegate didStartTouchesInRangeSlider:self];
+        if ([self.delegate respondsToSelector:@selector(rangeSlider:didStartTouchesInLeftHandle:orRightHandle:)]){
+            [self.delegate rangeSlider:self didStartTouchesInLeftHandle:self.leftHandleSelected orRightHandle:self.rightHandleSelected];
         }
 
         return YES;
@@ -457,15 +457,17 @@ static const CGFloat kLabelsFontSize = 12.0f;
 }
 
 - (void)endTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
+    
+    if ([self.delegate respondsToSelector:@selector(rangeSlider:didEndTouchesInLeftHandle:orRightHandle:)]){
+        [self.delegate rangeSlider:self didEndTouchesInLeftHandle:self.leftHandleSelected orRightHandle:self.rightHandleSelected];
+    }
+    
     if (self.leftHandleSelected){
         self.leftHandleSelected = NO;
         [self animateHandle:self.leftHandle withSelection:NO];
     } else {
         self.rightHandleSelected = NO;
         [self animateHandle:self.rightHandle withSelection:NO];
-    }
-    if ([self.delegate respondsToSelector:@selector(didEndTouchesInRangeSlider:)]) {
-        [self.delegate didEndTouchesInRangeSlider:self];
     }
 }
 

--- a/Pod/Classes/TTRangeSliderDelegate.h
+++ b/Pod/Classes/TTRangeSliderDelegate.h
@@ -21,11 +21,11 @@
 /**
  * Called when the user has finished interacting with the RangeSlider
  */
-- (void)didEndTouchesInRangeSlider:(TTRangeSlider *)sender;
+- (void)rangeSlider:(TTRangeSlider *)sender didEndTouchesInLeftHandle:(BOOL)leftSelected orRightHandle:(BOOL)rightSelected;
 
 /**
  * Called when the user has started interacting with the RangeSlider
  */
-- (void)didStartTouchesInRangeSlider:(TTRangeSlider *)sender;
+- (void)rangeSlider:(TTRangeSlider *)sender didStartTouchesInLeftHandle:(BOOL)leftSelected orRightHandle:(BOOL)rightSelected;
 
 @end


### PR DESCRIPTION
Changed:
`- (void)didEndTouchesInRangeSlider:(TTRangeSlider *)sender;`
`- (void)didStartTouchesInRangeSlider:(TTRangeSlider *)sender;`

To:
`- (void)rangeSlider:(TTRangeSlider *)sender didEndTouchesInLeftHandle:(BOOL)leftSelected orRightHandle:(BOOL)rightSelected;`

`- (void)rangeSlider:(TTRangeSlider *)sender didStartTouchesInLeftHandle:(BOOL)leftSelected orRightHandle:(BOOL)rightSelected; `

Allowing, for example, change `step` in real time like airbnb app.