### PR TITLE
Fixed interaction with gesture recognizers

### DIFF
--- a/Pod/Classes/TTRangeSlider.m
+++ b/Pod/Classes/TTRangeSlider.m
@@ -336,7 +336,11 @@ static const CGFloat kLabelsFontSize = 12.0f;
 }
 
 #pragma mark - Touch Tracking
-
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer {
+    //kill any gestures when we're tracking a touch that started on one of the handles. This ensures the correct behaviour when
+    //the superview is something like a scrollview that can accepts touches in the same area as the slider thats placed on that view.
+    return !self.isTracking;
+}
 
 - (BOOL)beginTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
     CGPoint gesturePressLocation = [touch locationInView:self];
@@ -457,7 +461,17 @@ static const CGFloat kLabelsFontSize = 12.0f;
     return YES;
 }
 
+- (void)cancelTrackingWithEvent:(UIEvent *)event {
+    [super cancelTrackingWithEvent:event];
+    [self cleanupTouch];
+}
+
 - (void)endTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event {
+    [super endTrackingWithTouch:touch withEvent:event];
+    [self cleanupTouch];
+}
+
+- (void)cleanupTouch {
     if (self.leftHandleSelected){
         self.leftHandleSelected = NO;
         [self animateHandle:self.leftHandle withSelection:NO];


### PR DESCRIPTION
If the range slider is placed on a view with a gesture recognizer (eg a scroll view)
the gesture recognizer can grab touch events making the slider difficult to control.
The Apple documentation for the UIView gestureRecognizerShouldBegin method mentions
that this method is used by UISlider to overcome this issue, so this is the approach
this patch uses.

The new page sheet presentation style in iOS 13 makes it more likely that the view
the range slider is on will have a gesture recognizer, and therefore be effected by
this problem.

While debugging this issue similar symptoms to issue #69 ("Handle stays enlarged
when tapped during drag of parent view") were encountered and fixed. The exact
reproduction steps described in issue 69 haven't been retested, but it's possible
this patch also fixes that issue.