### PR TITLE
Added SPM Support

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,8 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "TTRangeSlider",
-            dependencies: [],
-			path: "Pod/Classes"),
-    ]
+			dependencies: [],
+			path: "Pod/Classes",
+			publicHeadersPath: "."),
+	]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,29 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "TTRangeSlider",
+	platforms: [
+		.iOS(.v9),
+	],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "TTRangeSlider",
+            targets: ["TTRangeSlider"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "TTRangeSlider",
+            dependencies: [],
+			path: "Pod/Classes"),
+    ]
+)


### PR DESCRIPTION
This is a really simple library, so adding Swift Package Manager support is really easy even though it's all ObjC.

If you merge this in, all you need to do is create a tag for each release (which you do for Cocoapods anyway) and SPM handles the rest. Don't need to publish anywhere else.