### PR TITLE
Added the ability to set an image for both handles

### DIFF
--- a/Pod/Classes/TTRangeSlider.h
+++ b/Pod/Classes/TTRangeSlider.h
@@ -139,6 +139,11 @@ IB_DESIGNABLE
  */
 @property (nonatomic, strong) UIImage *handleImage;
 
+/**
+ * Handle slider with a custom image for both the right and left handles
+ */
+@property (nonatomic, strong) UIImage *rightHandleImage;
+@property (nonatomic, strong) UIImage *leftHandleImage;
 
 /**
  *Handle slider with custom border color, you can set custom border color for your handle

--- a/Pod/Classes/TTRangeSlider.h
+++ b/Pod/Classes/TTRangeSlider.h
@@ -142,8 +142,8 @@ IB_DESIGNABLE
 /**
  * Handle slider with a custom image for both the right and left handles
  */
-@property (nonatomic, strong) UIImage *rightHandleImage;
-@property (nonatomic, strong) UIImage *leftHandleImage;
+@property (nonatomic, strong) IBInspectable UIImage *rightHandleImage;
+@property (nonatomic, strong) IBInspectable UIImage *leftHandleImage;
 
 /**
  *Handle slider with custom border color, you can set custom border color for your handle

--- a/Pod/Classes/TTRangeSlider.m
+++ b/Pod/Classes/TTRangeSlider.m
@@ -658,9 +658,9 @@ static const CGFloat kLabelsFontSize = 12.0f;
     self.rightHandle.backgroundColor = [[UIColor clearColor] CGColor];
 }
 
--(void)setSeperateHandleImages:(*UIImage *)rightHandleImage andHandle: (UIImage *)leftHandleImage{
-    _leftHandleImage = leftHandleImage
-    _rightHandleImage = rightHandleImage
+-(void)setSeperateHandleImages:(UIImage *)rightHandleImage andHandle: (UIImage *)leftHandleImage{
+    _leftHandleImage = leftHandleImage;
+    _rightHandleImage = rightHandleImage;
     
     CGRect startFrame = CGRectMake(0.0, 0.0, 31, 32);
     self.leftHandle.contents = (id)rightHandleImage.CGImage;

--- a/Pod/Classes/TTRangeSlider.m
+++ b/Pod/Classes/TTRangeSlider.m
@@ -658,6 +658,22 @@ static const CGFloat kLabelsFontSize = 12.0f;
     self.rightHandle.backgroundColor = [[UIColor clearColor] CGColor];
 }
 
+-(void)setSeperateHandleImages:(*UIImage *)rightHandleImage andHandle: (UIImage *)leftHandleImage{
+    _leftHandleImage = leftHandleImage
+    _rightHandleImage = rightHandleImage
+    
+    CGRect startFrame = CGRectMake(0.0, 0.0, 31, 32);
+    self.leftHandle.contents = (id)rightHandleImage.CGImage;
+    self.leftHandle.frame = startFrame;
+    
+    self.rightHandle.contents = (id)leftHandleImage.CGImage;
+    self.rightHandle.frame = startFrame;
+    
+    //Force layer background to transparant
+    self.leftHandle.backgroundColor = [[UIColor clearColor] CGColor];
+    self.rightHandle.backgroundColor = [[UIColor clearColor] CGColor];
+}
+
 -(void)setHandleColor:(UIColor *)handleColor{
     _minHandleColor = handleColor;
     _maxHandleColor = handleColor;

--- a/Pod/Classes/TTRangeSlider.m
+++ b/Pod/Classes/TTRangeSlider.m
@@ -658,20 +658,28 @@ static const CGFloat kLabelsFontSize = 12.0f;
     self.rightHandle.backgroundColor = [[UIColor clearColor] CGColor];
 }
 
--(void)setSeperateHandleImages:(UIImage *)rightHandleImage andHandle: (UIImage *)leftHandleImage{
-    _leftHandleImage = leftHandleImage;
-    _rightHandleImage = rightHandleImage;
+-(void)setRightHandleImage:(UIImage *)handleImage{
+    _rightHandleImage = handleImage;
     
     CGRect startFrame = CGRectMake(0.0, 0.0, 31, 32);
-    self.leftHandle.contents = (id)rightHandleImage.CGImage;
-    self.leftHandle.frame = startFrame;
     
-    self.rightHandle.contents = (id)leftHandleImage.CGImage;
+    self.rightHandle.contents = (id)handleImage.CGImage;
     self.rightHandle.frame = startFrame;
     
     //Force layer background to transparant
-    self.leftHandle.backgroundColor = [[UIColor clearColor] CGColor];
     self.rightHandle.backgroundColor = [[UIColor clearColor] CGColor];
+}
+
+-(void)setLeftHandleImage:(UIImage *)handleImage{
+    _leftHandleImage = handleImage;
+    
+    CGRect startFrame = CGRectMake(0.0, 0.0, 31, 32);
+    
+    self.leftHandle.contents = (id)handleImage.CGImage;
+    self.leftHandle.frame = startFrame;
+    
+    //Force layer background to transparant
+    self.leftHandle.backgroundColor = [[UIColor clearColor] CGColor];
 }
 
 -(void)setHandleColor:(UIColor *)handleColor{


### PR DESCRIPTION
This gives users the ability to set separate handle images on the range slider. If they do not want to use this, they can still use handleImage to set a master image for both handles, or set no image at all.